### PR TITLE
Fix: Remove logging level from test traceability job

### DIFF
--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -60,7 +60,6 @@ jobs:
                      --env TT_JIRA_PROJECT_KEY="PSG" \
                      --env TT_JIRA_TEST_TYPE="unit" \
                      --env TT_JIRA_TOKEN=${{ secrets.JIRA_TOKEN }} \
-                     --env TT_LOG_LEVEL="DEBUG" \
                      --env TT_REPO_NAME="${{ env.REPO_NAME }}" \
                      --env TT_SHOULD_TRACE_RESULTS_TO_JIRA=${{ inputs.trace_to_jira }} \
                      --rm \


### PR DESCRIPTION
This PR removes the env var that sets the log level for the test traceability job, opting to fall back on the default, which is `INFO`. Please see [this PR](https://github.com/Congenica/rt-test-traceability/pull/29) for more information.